### PR TITLE
Feat/issue #74

### DIFF
--- a/src/apis/rank/rank.response.ts
+++ b/src/apis/rank/rank.response.ts
@@ -6,9 +6,27 @@ export interface PageData {
   data: UserData[];
 }
 
+export interface tierInfo {
+  tier: string;
+  totalExp: number;
+  currentExp: number;
+}
+
 export interface UserRankingResponse {
-  result: string;
-  data: PageData[];
-  message: string;
-  errorCode: string;
+  result: 'SUCCESS' | 'FAIL';
+  data: {
+    totalPage: number;
+    hasNext: boolean;
+    data: [
+      {
+        id: number;
+        nickname: 'string';
+        profileImageUrl: 'string';
+        email: 'string';
+        tierInfo: tierInfo;
+      },
+    ];
+  };
+  message: 'string';
+  errorCode: 'string';
 }

--- a/src/interface/apis/user/index.ts
+++ b/src/interface/apis/user/index.ts
@@ -1,7 +1,6 @@
 import { TierInfo } from '../tier';
 
 export interface UserData {
-  currentExp: any;
   id: number;
   nickname: string;
   profileImageUrl: string;

--- a/src/interface/apis/user/index.ts
+++ b/src/interface/apis/user/index.ts
@@ -1,6 +1,7 @@
 import { TierInfo } from '../tier';
 
 export interface UserData {
+  currentExp: any;
   id: number;
   nickname: string;
   profileImageUrl: string;

--- a/src/pages/rank/components/all/index.tsx
+++ b/src/pages/rank/components/all/index.tsx
@@ -4,29 +4,28 @@ import HighRank from '../high';
 import UserRank from '../user';
 import * as S from './styles';
 import { getUserRanking } from '@/apis/rank/rank.api';
-import { PageData, UserRankingResponse } from '@/apis/rank/rank.response';
+import { UserRankingResponse } from '@/apis/rank/rank.response';
+import { UserData } from '@/interface/apis/user';
 import { User } from '@/interface/userInterface';
 import * as Base from '@/styles/baseStyles';
 
 const AllRank = () => {
   const [userRanks, setUserRanks] = useState<User[]>([]);
-  const [, setLoading] = useState<boolean>(true);
+
+  const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
     const fetchUserRanking = async () => {
-      const data: UserRankingResponse = await getUserRanking(1, 10);
-      const pageData = data.data;
-
-      const allUserData: User[] = pageData.flatMap((page: PageData) =>
-        page.data.map((user) => ({
-          ...user,
-          currentExp: Math.floor(Math.random() * 1000), // Example logic for currentExp
-          tierInfo: user.tierInfo.toString(), // Convert tierInfo to string
-        }))
-      );
+      const response: UserRankingResponse = await getUserRanking(1, 10);
+      const pageData = response.data;
+      const allUserData: User[] = pageData.data.map((user: UserData) => ({
+        ...user,
+        currentExp: Math.floor(Math.random() * 1000),
+        tierInfo: user.tierInfo.tier,
+      }));
       setUserRanks(allUserData);
       setLoading(false);
-      console.log(data);
+      // console.log('rank data: ', allUserData);
     };
 
     fetchUserRanking();

--- a/src/pages/rank/components/high/index.tsx
+++ b/src/pages/rank/components/high/index.tsx
@@ -8,7 +8,7 @@ import { getTierDetails } from '@/constants/data/tierSchema';
 import { User } from '@/interface/userInterface';
 import * as Base from '@/styles/baseStyles';
 
-const gradeToTrophy = {
+const gradeToTrophy: { [key: number]: string } = {
   1: First,
   2: Second,
   3: Third,
@@ -24,9 +24,15 @@ const HighRank = ({ grade, user }: HighRankProps) => {
   const { nickname, profileImageUrl, tierInfo } = user;
 
   const tierDetails = tierInfo
-    ? getTierDetails(tierInfo.tier)
+    ? getTierDetails(tierInfo)
     : { color: 'var(--color-class-02)' };
 
+  console.log(tierDetails);
+  const truncateNickname = (nickname: string, maxLength: number) => {
+    return nickname.length > maxLength
+      ? `${nickname.slice(0, maxLength)}...`
+      : nickname;
+  };
   return (
     <S.HighRankLayout>
       <S.TrophyContainer>
@@ -38,7 +44,7 @@ const HighRank = ({ grade, user }: HighRankProps) => {
         height='1.5rem'
       />
       <Base.Text fontSize='1.2rem' fontWeight='700'>
-        {nickname}
+        {truncateNickname(nickname, 6)}
       </Base.Text>
       <TextContainer marginRight='1rem' direction='column'>
         <Base.Text
@@ -46,11 +52,11 @@ const HighRank = ({ grade, user }: HighRankProps) => {
           fontWeight='700'
           fontSize='0.8rem'
         >
-          {tierInfo.tier}
+          {tierInfo}
         </Base.Text>
-        <Base.TierGraph>
-          <Base.CurrentTierGraph background={tierDetails?.color} />
-        </Base.TierGraph>
+        <Base.TotalTierGraph>
+          <Base.CurrentTierGraph bgColor={tierDetails?.color} />
+        </Base.TotalTierGraph>
       </TextContainer>
     </S.HighRankLayout>
   );

--- a/src/pages/rank/components/my/index.tsx
+++ b/src/pages/rank/components/my/index.tsx
@@ -6,12 +6,11 @@ import { useInfoStore } from '@/store/useInfoStore';
 import * as Base from '@/styles/baseStyles';
 
 const MyRank = () => {
-  const { userNickname, userTier } = useInfoStore();
+  const { userInfo } = useInfoStore();
 
-  const tierDetails = userTier
-    ? getTierDetails(userTier)
+  const tierDetails = userInfo?.tierInfo
+    ? getTierDetails(userInfo?.tierInfo.tier)
     : { color: 'var(--color-class-02)' };
-  console.log(tierDetails?.color);
   return (
     <>
       <S.MyRankLayout>
@@ -27,18 +26,18 @@ const MyRank = () => {
             <Base.Text fontWeight='700'>1위</Base.Text>
           </S.RankPosition>
           <S.RankProfile>
-            <S.RankProfileImg src={Profile} />
+            <S.RankProfileImg width='4.5rem' src={Profile} />
           </S.RankProfile>
           <TextContainer>
             <Base.Text fontSize='var(--font-size-xl)' fontWeight='650'>
-              {userNickname}
+              {userInfo?.nickname}
             </Base.Text>
             <Base.Text
               color={tierDetails?.color}
               fontWeight='700'
               fontSize='1.2rem'
             >
-              {userTier}
+              {userInfo?.tierInfo.tier}
             </Base.Text>
           </TextContainer>
         </S.RankInfoContainer>

--- a/src/pages/rank/components/user/index.tsx
+++ b/src/pages/rank/components/user/index.tsx
@@ -2,7 +2,8 @@ import * as S from './styles';
 import Profile from '@/assets/main/ZZAN-Profile.png';
 import { getTierDetails } from '@/constants/data/tierSchema';
 import { User } from '@/interface/userInterface';
-import * as Base from '@/styles/baseStyles';
+import { CurrentTierGraph, TotalTierGraph } from '@/styles/baseStyles';
+import { Box, Img, Text } from '@chakra-ui/react';
 
 type UserRankProps = {
   user: User;
@@ -10,7 +11,6 @@ type UserRankProps = {
 };
 
 const UserRank: React.FC<UserRankProps> = ({ user, index }) => {
-  // const { nickname, profileImageUrl, tierInfo, currentExp } = user;
   const { nickname, tierInfo, currentExp } = user;
 
   const tierDetails = tierInfo
@@ -18,70 +18,75 @@ const UserRank: React.FC<UserRankProps> = ({ user, index }) => {
     : { color: 'var(--color-class-02)' };
 
   const tierColor = tierDetails?.color;
-  console.log(tierColor);
 
   return (
     <>
       <S.UserRankContainer>
-        <Base.Container
-          justifyContent='space-between'
+        <Box
+          display='flex'
+          // justifyContent='space-between'
           alignItems='center'
           textAlign='center'
           bgColor='#fff'
+          gap='1rem'
+          width='100%'
         >
-          <Base.Text fontWeight='700'>{index + 4}위</Base.Text>
-          <Base.Img src={Profile} width='1.5rem' height='1.5rem' />
-          <Base.Text fontWeight='700'>{nickname}</Base.Text>
-        </Base.Container>
-        <Base.Container
+          <Text fontWeight='700'>{index + 1}위</Text>
+          <Img src={Profile} width='1.5rem' height='1.5rem' />
+          <Text fontWeight='700'>{nickname}</Text>
+        </Box>
+        <Box
+          display='flex'
           width='100%'
           alignItems='center'
           textAlign='center'
           flexDirection='row'
           gap='1rem'
         >
-          <Base.Container
+          <Box
+            display='flex'
             width='100%'
             alignItems='center'
             textAlign='center'
             flexDirection='row'
             gap='1rem'
           >
-            <Base.Text
+            <Text
               maxWidth='150px'
               fontWeight='700'
               fontSize='0.8rem'
               color={tierColor}
             >
               {tierInfo}
-            </Base.Text>
-            <Base.Text maxWidth='150px' fontSize='0.8rem' color={tierColor}>
+            </Text>
+            <Text maxWidth='150px' fontSize='0.8rem' color={tierColor}>
               {currentExp}
-            </Base.Text>
-          </Base.Container>
-          <Base.Container
+            </Text>
+          </Box>
+          <Box
+            display='flex'
             width='100%'
             alignItems='center'
             textAlign='center'
             flexDirection='row'
             gap='1rem'
           >
-            <Base.TotalTierGraph
+            <TotalTierGraph
               width='100%'
               mgColumn='1rem'
               mgRow='0'
               height='0.3125rem'
               radius='0.125rem'
             >
-              <Base.CurrentTierGraph
+              <CurrentTierGraph
                 width='1rem'
                 height='0.3125rem'
                 radius='0.125rem'
                 bgColor={tierColor}
               />
-            </Base.TotalTierGraph>
-          </Base.Container>
-        </Base.Container>
+            </TotalTierGraph>
+          </Box>
+        </Box>
       </S.UserRankContainer>
     </>
   );


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

- 유저 랭킹 중 최상위 10명에 해당하는 랭킹 조회 기능 구현
- 내 랭킹 조회 기능 구현
- 1 ~ 3위와 4 ~ 10위 랭킹 나눠서 표시할 수 있도록 컴포넌트 분리
- 유저 닉네임이 너무 길어질 때, `nickname...` 으로 축약하여 표시
- 공통 스타일에서 차크라 ui로 수정

---

### ✨ 참고 사항

---

### ⏰ 현재 버그
- 내 랭킹만 볼 수 있는 상단 부분에서 전체랭킹에서 내 랭킹을 찾아서 가져오는 기능은 구현하지 못했습니다.
- 해당 기능은 FE에서 직접 찾아서 가져오는 방식을 사용하거나, BE에서 내 랭킹 조회만 가능한 api를 만들어 줄 수 있는지 협의 후 결정하도록 하겠습니다.

---

### ✏ Git Close
closes #74 