### PR TITLE
fix(tab): 탭 선택 이벤트핸들러의 파라미터 수정 (마우스이벤트 e 삭제)

### DIFF
--- a/src/components/common/tab/index.tsx
+++ b/src/components/common/tab/index.tsx
@@ -1,11 +1,4 @@
-import {
-  cloneElement,
-  MouseEvent,
-  ReactElement,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { cloneElement, ReactElement, useEffect, useRef, useState } from 'react';
 
 import * as S from './styles';
 
@@ -18,10 +11,7 @@ type TabProps = {
 
 type TabsProps = {
   selectedTab: number;
-  onChange: (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
-    value: number
-  ) => void;
+  onChange: (value: number) => void;
   children: ReactElement[];
   position?: string;
 };
@@ -58,8 +48,8 @@ export const Tabs = ({
   const sliderWidth = containerWidth / children.length;
 
   const tabs = children.map((child) => {
-    const handleClick = (e: MouseEvent<HTMLDivElement, MouseEvent>) => {
-      onChange(e, child.props.value);
+    const handleClick = () => {
+      onChange(child.props.value);
     };
 
     return cloneElement(child, {

--- a/src/pages/challenge-detail/index.tsx
+++ b/src/pages/challenge-detail/index.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { getChallengeDetail } from '../../apis/challenge-detail/challenge.detail.api';
 import Description from './description/';
@@ -20,10 +20,7 @@ const ChallengeDetailPage = () => {
   const [activeTab, setActiveTab] = useState<number>(0);
   const [data, setData] = useState<ChallengeDetailData | undefined>(undefined);
 
-  const handleSelectedTab = (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
-    value: number
-  ) => {
+  const handleSelectedTab = (value: number) => {
     setActiveTab(value);
   };
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

close #111 
- fix(tab): 탭 선택 이벤트핸들러의 파라미터 수정 (마우스이벤트 e 삭제)
- 선언 후 사용하지 않은 마우스이벤트 e라는 변수 삭제

---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close
