### PR TITLE
챌린지 상세 페이지 랭킹 섹션 무한 스크롤 고치기 #121

### DIFF
--- a/src/apis/challenge-detail/challenge.ranking.api.ts
+++ b/src/apis/challenge-detail/challenge.ranking.api.ts
@@ -1,24 +1,25 @@
 import { AxiosError } from 'axios';
 
 import { axiosClient } from '../AxiosClient';
-import { ChallengeRankingData } from './challenge.ranking.response';
+import type { GetChallengeRankingResponse } from './challenge.ranking.response';
 
 type ChallengeRankingParams = {
-  id: number;
+  challengeGroupId: number;
   page: number;
   size: number;
 };
 
 export async function getChallengeRanking({
-  id,
+  challengeGroupId,
   page,
   size,
-}: ChallengeRankingParams): Promise<ChallengeRankingData[]> {
+}: ChallengeRankingParams): Promise<GetChallengeRankingResponse> {
   try {
     const response = await axiosClient.get(
-      `api/challengeGroups/${id}/rankings?page=${page}&size=${size}`
+      `api/challengeGroups/${challengeGroupId}/rankings?page=${page}&size=${size}`
     );
-    // console.log('getChallengeRanking response: ', response.data);
+    // console.log('getReview response: ', response.data); // 전체 응답 로그
+    // console.log('getReview response data: ', response.data.data); // 실제 데이터 부분 확인
     return response.data.data;
   } catch (error) {
     if (error instanceof AxiosError) {

--- a/src/apis/challenge-detail/challenge.ranking.response.ts
+++ b/src/apis/challenge-detail/challenge.ranking.response.ts
@@ -88,3 +88,14 @@ export const DummyRankingList: ChallengeRankingData[] = [
     },
   },
 ];
+
+export type GetChallengeRankingResponse = {
+  totalPage: number;
+  hasNext?: boolean;
+  myRanking?: {
+    ranking: number;
+    acquiredPoint: number;
+    user: UserData;
+  };
+  data: ChallengeRankingData[];
+};

--- a/src/apis/challenge-detail/challenge.ranking.response.ts
+++ b/src/apis/challenge-detail/challenge.ranking.response.ts
@@ -1,3 +1,14 @@
+export type GetChallengeRankingResponse = {
+  totalPage: number;
+  hasNext?: boolean;
+  myRanking?: {
+    ranking: number;
+    acquiredPoint: number;
+    user: UserData;
+  };
+  data: ChallengeRankingData[];
+};
+
 export type UserData = {
   id: number;
   nickname: string;
@@ -14,7 +25,6 @@ export type ChallengeRankingData = {
   acquiredPoint: number;
   user: UserData;
 };
-// ChallengeRankingData[]로 반환됨
 
 export const DummyRankingList: ChallengeRankingData[] = [
   {
@@ -88,14 +98,3 @@ export const DummyRankingList: ChallengeRankingData[] = [
     },
   },
 ];
-
-export type GetChallengeRankingResponse = {
-  totalPage: number;
-  hasNext?: boolean;
-  myRanking?: {
-    ranking: number;
-    acquiredPoint: number;
-    user: UserData;
-  };
-  data: ChallengeRankingData[];
-};

--- a/src/apis/review/review.response.ts
+++ b/src/apis/review/review.response.ts
@@ -1,5 +1,11 @@
 import { TierInfo } from './../../interface/apis/tier/index';
 
+export type GetReviewResponse = {
+  totalPage: number;
+  hasNext: boolean;
+  data: ReviewData[];
+};
+
 export type User = {
   id: number;
   nickname: string;
@@ -16,7 +22,7 @@ export type ReviewData = {
   rating: number;
 };
 
-export const DummyReviewData: ReviewData[] = [
+export const DummyReviewList: ReviewData[] = [
   {
     challengeId: 1,
     challengeTitle: '쓰레기 줍기 챌린지',
@@ -36,12 +42,6 @@ export const DummyReviewData: ReviewData[] = [
     rating: 4,
   },
 ];
-
-export type GetReviewResponse = {
-  totalPage: number;
-  hasNext: boolean;
-  data: ReviewData[];
-};
 
 //
 

--- a/src/pages/challenge-detail/components/ranking-item/styles.ts
+++ b/src/pages/challenge-detail/components/ranking-item/styles.ts
@@ -17,7 +17,7 @@ export const Content = styled.div`
 
 export const Rank = styled.div<{ ranking: number }>`
   font-size: var(--font-size-md);
-  font-weight: ${({ ranking }) => (ranking <= 3 ? `bold` : `regular`)};
+  font-weight: ${({ ranking }) => (ranking <= 3 ? `600` : `400`)};
   color: ${({ ranking }) => (ranking <= 3 ? `var(--color-green-01)` : `#000`)};
 `;
 

--- a/src/pages/challenge-detail/index.tsx
+++ b/src/pages/challenge-detail/index.tsx
@@ -10,6 +10,8 @@ import DefaultImage from '@/assets/Default-Image.svg';
 import { Tab, TabPanel, Tabs } from '@/components/common/tab';
 import TopBar from '@/components/features/layout/top-bar';
 
+const CHALLENGE_GROUP_ID = 38;
+
 const ChallengeDetailPage = () => {
   const [activeTab, setActiveTab] = useState<number>(() => {
     // 세션 스토리지에 저장된 값 | 기본값 0
@@ -23,8 +25,14 @@ const ChallengeDetailPage = () => {
       label: '설명',
       component: data ? <DescriptionSection data={data} /> : null,
     },
-    { label: '랭킹', component: data ? <RankingSection id={data.id} /> : null },
-    { label: '리뷰', component: data ? <ReviewSection id={data.id} /> : null },
+    {
+      label: '랭킹',
+      component: data ? <RankingSection id={CHALLENGE_GROUP_ID} /> : null,
+    },
+    {
+      label: '리뷰',
+      component: data ? <ReviewSection id={CHALLENGE_GROUP_ID} /> : null,
+    },
   ];
 
   const handleSelectedTab = (value: number) => {
@@ -35,7 +43,7 @@ const ChallengeDetailPage = () => {
   useEffect(() => {
     const fetchChallengeDetail = async () => {
       try {
-        const res = await getChallengeDetail(20);
+        const res = await getChallengeDetail(CHALLENGE_GROUP_ID);
         setData(res);
       } catch (error) {
         console.error(error);

--- a/src/pages/challenge-detail/ranking-section/index.tsx
+++ b/src/pages/challenge-detail/ranking-section/index.tsx
@@ -4,10 +4,7 @@ import { useInView } from 'react-intersection-observer';
 import { RankingItem } from '../components/ranking-item/';
 import * as S from './styles';
 import { getChallengeRanking } from '@/apis/challenge-detail/challenge.ranking.api';
-import {
-  type ChallengeRankingData,
-  DummyRankingList,
-} from '@/apis/challenge-detail/challenge.ranking.response';
+import { type ChallengeRankingData } from '@/apis/challenge-detail/challenge.ranking.response';
 import * as Base from '@/styles/baseStyles';
 
 type RankingSectionProps = {
@@ -16,26 +13,32 @@ type RankingSectionProps = {
 
 export const RankingSection = ({ id }: RankingSectionProps) => {
   const DATA_SIZE = 10;
-  const [rankingList, setRankingList] =
-    useState<ChallengeRankingData[]>(DummyRankingList);
-  const [page, setPage] = useState<number>(1);
-  const [ref, inView] = useInView({ threshold: 0.8 });
-  const [isFetching, setIsFetching] = useState<boolean>(false);
-  const [hasMore, setHasMore] = useState<boolean>(true); // 데이터 없을 때 호출 방지
+  const [rankingList, setRankingList] = useState<ChallengeRankingData[]>([]);
+  const [page, setPage] = useState<number>(0); // 0부터 시작
+  const { ref, inView } = useInView({ threshold: 0.8 });
+  const [isFetching, setIsFetching] = useState<boolean>(false); // 로딩 UI 렌더링 여부
+  const [hasNext, setHasNext] = useState<boolean>(true); // 데이터 없을 때 호출 방지
 
   useEffect(() => {
-    if (inView && hasMore && !isFetching) {
+    if (inView && hasNext && !isFetching) {
       setIsFetching(true);
-      getChallengeRanking({ id, page, size: DATA_SIZE })
-        .then((data) => {
-          if (Array.isArray(data) && data.length > 0) {
-            // 데이터가 있을 때
-            setRankingList((prevRankingList) => [...prevRankingList, ...data]);
+
+      getChallengeRanking({ challengeGroupId: id, page, size: DATA_SIZE })
+        .then((res) => {
+          // 데이터가 있을 때
+          if (Array.isArray(res.data) && res.data.length > 0) {
+            setRankingList((prevRankingList) => [
+              ...prevRankingList,
+              ...res.data,
+            ]);
+            // console.log(`랭킹 리스트: `, rankingList); // test
+            setHasNext(page < res.totalPage);
             setPage((prevPage) => prevPage + 1);
-          } else {
-            // 데이터가 없을 때
-            setHasMore(false);
-            console.log('더 이상 데이터가 없습니다.');
+          }
+          // 데이터가 더 이상 없을 때
+          else {
+            setHasNext(false);
+            console.log('리뷰가 더 이상 없습니다.');
           }
         })
         .catch((error) => {
@@ -45,7 +48,7 @@ export const RankingSection = ({ id }: RankingSectionProps) => {
           setIsFetching(false);
         });
     }
-  }, [inView, isFetching, hasMore, id, page]);
+  }, [inView, hasNext, isFetching, id, page]);
 
   return (
     <S.RankingWrapper>
@@ -61,7 +64,6 @@ export const RankingSection = ({ id }: RankingSectionProps) => {
               {/* 마지막 요소 뒤에는 Line을 넣지 않음 */}
             </div>
           ))}
-          <S.Text ref={ref}>{isFetching ? '로딩 중...' : ' '}</S.Text>
         </>
       ) : (
         // 랭킹 없을 때
@@ -74,6 +76,7 @@ export const RankingSection = ({ id }: RankingSectionProps) => {
           가 되어보세요!
         </S.Text>
       )}
+      <S.Text ref={ref}>{isFetching ? '로딩 중...' : ' '}</S.Text>
     </S.RankingWrapper>
   );
 };

--- a/src/pages/review/index.tsx
+++ b/src/pages/review/index.tsx
@@ -48,7 +48,7 @@ const Review = () => {
           setIsFetching(false);
         });
     }
-  }, [inView, hasNext, challengeGroupId, page]);
+  }, [inView, hasNext, isFetching, challengeGroupId, page]);
 
   return (
     <>


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

close #121 
- 랭킹 불러오는 함수 리턴 타입 맞게 고치고
- 무한스크롤 구현
- 랭킹 아이템 디자인도 약간 수정

---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close
